### PR TITLE
Commit all pom.xml files in project

### DIFF
--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -34,7 +34,7 @@ jobs:
         run: mvn versions:set -DnewVersion=$NEW_VERSION --no-transfer-progress
       - name: Commit and tag new version
         run: |
-          git add pom.xml
+          git add pom.xml **/pom.xml
           git commit -m "[actions] Updated version in pom.xml to $NEW_VERSION"
           git tag $NEW_VERSION
       - name: Increment version
@@ -43,7 +43,7 @@ jobs:
           mvn versions:set -DnewVersion="${{ github.event.inputs.major }}.${{ github.event.inputs.minor }}.$NEXT_PATCH-SNAPSHOT" -DallowSnapshots --no-transfer-progress
       - name: Commit new version for next dev cycle
         run: |
-          git add **/pom.xml
+          git add pom.xml **/pom.xml
           git commit -m "[actions] Next development cycle"
       - name: Push back to GitHub
         run: git push --all


### PR DESCRIPTION
- Follow up to https://github.com/rcsb/devops-cicd-github-actions/commit/81bb12c75a25821a7df80e7b655ff6d7f28e771f
- This should happen for both the tag and the next dev cycle steps
- `git add **/pom.xml` doesn't work for the project root (https://github.com/rcsb/rcsb-seqmotif/actions/runs/4117418836/jobs/7108691704) despite being OK when run locally, might be sh-specific or something