### PR TITLE
Adding deploy to build-locker for branches

### DIFF
--- a/.github/workflows/push-to-branch.yaml
+++ b/.github/workflows/push-to-branch.yaml
@@ -5,7 +5,15 @@ on:
     branches-ignore:
       - "master"
       - "main"
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      distribution:
+        type: string
+        required: true
+      type:
+        type: string
+        default: "jar"
+        required: false
 
 concurrency:
   group: ${{ github.ref }}
@@ -19,3 +27,9 @@ jobs:
     uses: rcsb/devops-cicd-github-actions/.github/workflows/build-and-push-docker.yaml@master
     with:
       tag: "${{ github.ref_name }}"
+  call-deploy-to-buildlocker:
+    needs: tst
+    uses: rcsb/devops-cicd-github-actions/.github/workflows/deploy-to-buildlocker.yaml@master
+    with:
+      distribution: ${{ inputs.distribution }}
+      type: ${{ inputs.type }}

--- a/.github/workflows/push-to-branch.yaml
+++ b/.github/workflows/push-to-branch.yaml
@@ -28,7 +28,7 @@ jobs:
     with:
       tag: "${{ github.ref_name }}"
   call-deploy-to-buildlocker:
-    needs: tst
+    needs: test
     uses: rcsb/devops-cicd-github-actions/.github/workflows/deploy-to-buildlocker.yaml@master
     with:
       distribution: ${{ inputs.distribution }}


### PR DESCRIPTION
@Ingvord could you have a look. I think this should be sufficient for deploying branches to BL

This is to get us going for the time being. We'll also remove it once more advanced with k8s