### PR TITLE
Create example Helm Chart template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # devops-cicd-github-actions
 
-Shared library of GitHub Actions Workflows to standardize CI/CD operations for RCSB repositories.
+Shared library of GitHub Actions Workflows and files to standardize CI/CD operations for RCSB repositories.
 
 # Using this library
 
 Within the GitHub repository for your application, you will need to create and include the `.yaml` files under the `.github/workflows` directory in order to enable the automated CI/CD pipelines to handle linting, testing, builds, and deployments.
+
+To package your application as a Helm chart, add the `templates/helm` directory under the root of your project as `k8s/helm`. Modify the values in the `Chart.yaml` and `values.yaml` files to fit the project needs.
+
+To deploy your application using Skaffold, add the `templates/skaffold.yaml` file to the root of your project as `skaffold.yaml`. Modify the `releases.name` values to match the application.
 
 To learn more about GitHub Actions workflows, see [this link](https://docs.github.com/en/actions/using-workflows/about-workflows).
 

--- a/templates/helm/.helmignore
+++ b/templates/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/templates/helm/Chart.yaml
+++ b/templates/helm/Chart.yaml
@@ -1,0 +1,28 @@
+apiVersion: v2
+# TODO: Rename the helm chart to match your application. Select a single word name if possible, all lowercase.
+name: example_application
+description: An example Helm chart for the RCSB Kubernetes Environment
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+#
+# Most likely you will use an application type chart.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version reference of the application being deployed. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: ""
+
+# TODO: Remove these comment blocks from the file once they are set and included in your application repository.

--- a/templates/helm/templates/_helpers.tpl
+++ b/templates/helm/templates/_helpers.tpl
@@ -1,0 +1,53 @@
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "helm_chart.fullname" -}}
+{{- if contains .Chart.Name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "helm_chart.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "helm_chart.labels" -}}
+helm.sh/chart: {{ include "helm_chart.chart" . }}
+{{ include "helm_chart.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "helm_chart.selectorLabels" -}}
+app.kubernetes.io/name: {{ .Chart.Name }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Persistent volume name. Utilize namespace aware naming to allow deployments of cluster resources for different environments.
+*/}}
+{{- define "helm_chart.pvname" -}}
+{{- printf "%s-%s" .Release.Namespace .Chart.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+ConfigMap resource name. Ensure names conform to character limits in Kubernetes
+*/}}
+{{- define "helm_chart.configmapName" -}}
+{{- printf "%s-config" (include "helm_chart.fullname" . | trunc 56 | trimSuffix "-") }}
+{{- end }}

--- a/templates/helm/templates/configmap.yaml
+++ b/templates/helm/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.useAppConfigs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "helm_chart.fullname" . }}-config
+  labels:
+    {{- include "helm_chart.labels" . | nindent 4 }}
+data:
+{{- range $file, $_ := .Values.appConfigs }}
+  {{ $file }}: |
+{{ $_.value | indent 4 }}
+{{- end -}}
+{{- end }}

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -69,10 +69,10 @@ spec:
               mountPath: "{{ .mountPath }}/{{ .filename }}"
               subPath: {{ .filename | quote }}
             {{- end }}
-            {{- range $key, $_ := .Values.appConfigs }}
-            - name: {{ include "helm_chart.configmapName" . }}
-              mountPath: "{{ $_.mountPath }}/{{ $_.filename }}"
-              subPath: {{ $_.filename | quote }}
+            {{- range .Values.appConfigs }}
+            - name: {{ include "helm_chart.configmapName" $ }}
+              mountPath: "{{ .mountPath }}/{{ .filename }}"
+              subPath: {{ .filename | quote }}
             {{- end }}
           {{- end }}
       {{- if or .Values.usePersistentVolume .Values.useSecretsVolume .Values.useAppConfigs}}

--- a/templates/helm/templates/deployment.yaml
+++ b/templates/helm/templates/deployment.yaml
@@ -1,0 +1,95 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "helm_chart.fullname" . }}
+  labels:
+    {{- include "helm_chart.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "helm_chart.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: {{ .Values.deploymentStrategy.type }}
+    {{- if eq .Values.deploymentStrategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.deploymentStrategy.maxSurge }}
+      maxUnavailable: {{ .Values.deploymentStrategy.maxUnavailable }}
+    {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "helm_chart.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- if .Values.livenessProbe.enable }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.livenessProbe.http.path }}
+              port: http
+          {{- end }}
+          {{- if .Values.readinessProbe.enable }}
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            httpGet:
+              path: {{ .Values.readinessProbe.http.path }}
+              port: http
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- if or .Values.usePersistentVolume .Values.useSecretsVolume .Values.useAppConfigs }}
+          volumeMounts:
+            {{- if .Values.usePersistentVolume }}
+            - mountPath: {{ .Values.persistentVolumeMountPath }}
+              name: {{ include "helm_chart.pvname" . }}
+              readOnly: {{ .Values.persistentVolumeReadOnly }}
+            {{- end }}
+            {{- range .Values.secretVolumes }}
+            - name: {{ .name | quote }}
+              mountPath: "{{ .mountPath }}/{{ .filename }}"
+              subPath: {{ .filename | quote }}
+            {{- end }}
+            {{- range $key, $_ := .Values.appConfigs }}
+            - name: {{ include "helm_chart.configmapName" . }}
+              mountPath: "{{ $_.mountPath }}/{{ $_.filename }}"
+              subPath: {{ $_.filename | quote }}
+            {{- end }}
+          {{- end }}
+      {{- if or .Values.usePersistentVolume .Values.useSecretsVolume .Values.useAppConfigs}}
+      volumes:
+        {{- if .Values.usePersistentVolume }}
+        - name: {{ include "helm_chart.pvname" . }}
+          persistentVolumeClaim:
+            claimName: {{ include "helm_chart.pvname" . }}
+        {{- end }}
+        {{- range .Values.secretVolumes }}
+        - name: {{ .name | quote }}
+          secret:
+            secretName: {{ .secretName | quote }}
+        {{- end }}
+        {{- if .Values.useAppConfigs }}
+        - name: {{ include "helm_chart.configmapName" . }}
+          configMap:
+            name: {{ include "helm_chart.configmapName" . }}
+        {{- end }}
+      {{- end }}

--- a/templates/helm/templates/externalSecrets.yaml
+++ b/templates/helm/templates/externalSecrets.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.externalSecret.enabled -}}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "helm_chart.fullname" . }}
+spec:
+  refreshInterval: 15s
+  secretStoreRef:
+    name: {{ .Values.externalSecret.secretStoreRefName }}
+    kind: ClusterSecretStore
+  {{- range .Values.externalSecret.targets }}
+  target:
+    name: {{ .secretName }}
+  data:
+    {{- toYaml .data | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/templates/helm/templates/filesystem.yaml
+++ b/templates/helm/templates/filesystem.yaml
@@ -1,0 +1,51 @@
+{{ if .Values.usePersistentVolume }}
+apiVersion: ceph.rook.io/v1
+kind: CephFilesystem
+metadata:
+  name: {{ include "helm_chart.pvname" . }}
+  namespace: rook-ceph
+spec:
+  metadataPool:
+    replicated:
+      size: {{ .Values.rookCeph.metadataPoolSize }}
+  dataPools:
+    - name: replicated
+      replicated:
+        size: {{ .Values.rookCeph.dataPoolSize }}
+  preserveFilesystemOnDelete: {{ .Values.rookCeph.preserveFilesystemOnDelete }}
+  metadataServer:
+    activeCount: 1
+    activeStandby: true
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ include "helm_chart.pvname" . }}
+provisioner: rook-ceph.cephfs.csi.ceph.com
+parameters:
+  clusterID: rook-ceph
+  fsName: {{ include "helm_chart.pvname" . }}
+  pool: {{ include "helm_chart.pvname" . }}
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+reclaimPolicy: {{ .Values.rookCeph.reclaimPolicy }}
+allowVolumeExpansion: {{ .Values.rookCeph.allowVolumeExpansion }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "helm_chart.pvname" . }}
+spec:
+  storageClassName: {{ include "helm_chart.pvname" . }}
+  accessModes:
+    {{- range .Values.rookCeph.pvcAccessModes }}
+    - {{ . }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.rookCeph.pvcRequestStorageSize }}
+{{ end }}

--- a/templates/helm/templates/hpa.yaml
+++ b/templates/helm/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "helm_chart.fullname" . }}
+  labels:
+    {{- include "helm_chart.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "helm_chart.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/templates/helm/templates/ingress.yaml
+++ b/templates/helm/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "helm_chart.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "helm_chart.fullname" . }}
+  labels:
+    {{- include "helm_chart.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/templates/helm/templates/service.yaml
+++ b/templates/helm/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "helm_chart.fullname" . }}
+  labels:
+    {{- include "helm_chart.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "helm_chart.selectorLabels" . | nindent 4 }}

--- a/templates/helm/values.yaml
+++ b/templates/helm/values.yaml
@@ -32,12 +32,12 @@ externalSecret:
   enabled: false
   secretStoreRefName: "rcsb-vault"
   targets:
-    secretName: # Name of the secret resource to create in K8s
-    data: {}
-    # - secretKey: key_name_to_create_in_Secret_k8s_resource
-    #   remoteRef:
-    #     key: vault_engine_name/secret_name
-    #     property: name_of_key_of_secret_in_vault
+    - secretName: # Name of the secret resource to create in K8s
+      data: {}
+      #  - secretKey: key_name_to_create_in_Secret_k8s_resource
+      #    remoteRef:
+      #      key: vault_engine_name/secret_name
+      #      property: name_of_key_of_secret_in_vault
 
 # imagePullSecrets is the Secret resource which contains the credentials to connect to Docker
 # to pull images from private Harbor projects. If the image for your Helm chart is not from a

--- a/templates/helm/values.yaml
+++ b/templates/helm/values.yaml
@@ -1,0 +1,156 @@
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+# TODO: Remove any extra comment blocks and unused variable values.
+
+# Number of running Pods managed by this Helm chart's Deployment resource.
+# If using autoscaling, comment or remove this value.
+replicaCount: 1
+
+# Configure a HorizontalPodAutoscaler resource for this Helm chart's Deployment resource.
+# Set autoscaling.enabled to true to enable this functionality. If using this resource,
+# either choose to scale by targetCPUUtilizationPercentage or targetMemoryUtilizationPercentage
+# based on how you want the Deployment to scale, and comment or remove the other value option.
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# The Docker image reference which this Helm chart will run.
+# TODO: Ensure the repository/image name is correct.
+image:
+  repository: "harbor.devops.k8s.rcsb.org/rcsb/example_application"
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# externalSecret defines values for the ExternalSecret resource if your application needs to pull values
+# from an external Vault service.
+# TODO: Review externalSecret values as required.
+externalSecret:
+  enabled: false
+  secretStoreRefName: "rcsb-vault"
+  targets:
+    secretName: # Name of the secret resource to create in K8s
+    data: {}
+    # - secretKey: key_name_to_create_in_Secret_k8s_resource
+    #   remoteRef:
+    #     key: vault_engine_name/secret_name
+    #     property: name_of_key_of_secret_in_vault
+
+# imagePullSecrets is the Secret resource which contains the credentials to connect to Docker
+# to pull images from private Harbor projects. If the image for your Helm chart is not from a
+# private Harbor project, you can exclude this value. Otherwise, leave this value as is.
+imagePullSecrets: "harbor-docker-registry-conf"
+
+deploymentStrategy:
+  #https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  #Type is either RollingUpdate or Recreate
+  type: "RollingUpdate"
+  #For rolling update, what percentage of total pods can be created above desired amount
+  maxSurge: 25%
+  #For rolling update, what percentage of total pods can be brought down to update
+  maxUnavailable: 25%
+
+# securityContext sets the container security values of the Pod. These default values are the recommended
+# values for all applications. Adjust as needed for your application purposes, but be aware of the security
+# implications from these changes.
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# Define container liveness and readiness checks
+# A Pod is considered "live" when it is able to respond to client requests.
+# A Pod is considered "ready" when it has completed initialization and should be one of the backends for a K8s Service resource.
+# TODO: Enable/disable probes as required, and set appropriate values.
+livenessProbe:
+  enable: true
+  initialDelaySeconds: 300
+  periodSeconds: 30
+  failureThreshold: 6
+  http:
+    path: /
+readinessProbe:
+  enable: true
+  initialDelaySeconds: 300
+  periodSeconds: 30
+  failureThreshold: 6
+  http:
+    path: /
+
+# service declares the type of Service resource to be created, as well as the target port of the Pod to send requests.
+service:
+  type: ClusterIP
+  port: 80
+
+# ingress declares the Ingress resource to be created and allow access to the service from the external internet.
+# Set ingress.enabled to true to create this Ingress resource. Double-check the host values for your application.
+# TODO: Review ingress values.
+ingress:
+  enabled: false
+  className: "haproxy"
+  annotations: {}
+    # cert-manager.io/cluster-issuer: rutgers-acme
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: example-application.k8s.rcsb.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: example-application-tls
+  #    hosts:
+  #      - example-application.k8s.rcsb.org
+
+# Define resource limits for your application. Especially important if you enable autoscaling for this Helm chart.
+# Deploy without limits first to test the application performance, then tune afterwards to ensure that autoscaling
+# will work as expected.
+# TODO: Review resource limit values.
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+# usePersistentVolume if your application requires a persistent volume resource for data storage.
+# TODO: Review persistent volume values as required.
+usePersistentVolume: false
+# persistentVolumeMountPath defines the local path within the container where the persistent volume will be mounted.
+persistentVolumeMountPath: ""
+persistentVolumeReadOnly: true
+rookCeph:
+  metadataPoolSize: 3
+  dataPoolSize: 3
+  preserveFilesystemOnDelete: false
+  # reclaimPolicy are either Delete or Retain. See https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming
+  reclaimPolicy: Retain
+  allowVolumeExpansion: true
+  pvcRequestStorageSize: 50G
+  pvcAccessModes:
+    - ReadWriteMany
+
+# useSecretsVolume if your application will mount a secret from the Vault service as a file on the filesystem.
+useSecretsVolume: false
+secretVolumes: {}
+#  - name: Name of the volume reference in the Deployment resource
+#    mountPath: Full path in the container to mount the secret file
+#    filename: The filename of the secret file to mount
+#    secretName: Name of the Secret resource in K8s
+
+# appConfigs defines ConfigMap resources which are mounted into the container environment as a file.
+useAppConfigs: false
+appConfigs: {}
+#  example.log4j.xml:
+#    mountPath: Full path in the container to mount this config file
+#    filename: The filename of the config file to mount
+#    value: |-
+#      <example>
+#        Can be any other file types besides xml as well!
+#      </example>

--- a/templates/helm/values/production.yaml
+++ b/templates/helm/values/production.yaml
@@ -32,12 +32,12 @@ externalSecret:
   enabled: false
   secretStoreRefName: "rcsb-vault"
   targets:
-    secretName: # Name of the secret resource to create in K8s
-    data: {}
-    # - secretKey: key_name_to_create_in_Secret_k8s_resource
-    #   remoteRef:
-    #     key: vault_engine_name/secret_name
-    #     property: name_of_key_of_secret_in_vault
+    - secretName: # Name of the secret resource to create in K8s
+      data: {}
+      #  - secretKey: key_name_to_create_in_Secret_k8s_resource
+      #    remoteRef:
+      #      key: vault_engine_name/secret_name
+      #      property: name_of_key_of_secret_in_vault
 
 # imagePullSecrets is the Secret resource which contains the credentials to connect to Docker
 # to pull images from private Harbor projects. If the image for your Helm chart is not from a

--- a/templates/helm/values/production.yaml
+++ b/templates/helm/values/production.yaml
@@ -1,0 +1,156 @@
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+# TODO: Remove any extra comment blocks and unused variable values.
+
+# Number of running Pods managed by this Helm chart's Deployment resource.
+# If using autoscaling, comment or remove this value.
+replicaCount: 1
+
+# Configure a HorizontalPodAutoscaler resource for this Helm chart's Deployment resource.
+# Set autoscaling.enabled to true to enable this functionality. If using this resource,
+# either choose to scale by targetCPUUtilizationPercentage or targetMemoryUtilizationPercentage
+# based on how you want the Deployment to scale, and comment or remove the other value option.
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# The Docker image reference which this Helm chart will run.
+# TODO: Ensure the repository/image name is correct.
+image:
+  repository: "harbor.devops.k8s.rcsb.org/rcsb/example_application"
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# externalSecret defines values for the ExternalSecret resource if your application needs to pull values
+# from an external Vault service.
+# TODO: Review externalSecret values as required.
+externalSecret:
+  enabled: false
+  secretStoreRefName: "rcsb-vault"
+  targets:
+    secretName: # Name of the secret resource to create in K8s
+    data: {}
+    # - secretKey: key_name_to_create_in_Secret_k8s_resource
+    #   remoteRef:
+    #     key: vault_engine_name/secret_name
+    #     property: name_of_key_of_secret_in_vault
+
+# imagePullSecrets is the Secret resource which contains the credentials to connect to Docker
+# to pull images from private Harbor projects. If the image for your Helm chart is not from a
+# private Harbor project, you can exclude this value. Otherwise, leave this value as is.
+imagePullSecrets: "harbor-docker-registry-conf"
+
+deploymentStrategy:
+  #https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  #Type is either RollingUpdate or Recreate
+  type: "RollingUpdate"
+  #For rolling update, what percentage of total pods can be created above desired amount
+  maxSurge: 25%
+  #For rolling update, what percentage of total pods can be brought down to update
+  maxUnavailable: 25%
+
+# securityContext sets the container security values of the Pod. These default values are the recommended
+# values for all applications. Adjust as needed for your application purposes, but be aware of the security
+# implications from these changes.
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# Define container liveness and readiness checks
+# A Pod is considered "live" when it is able to respond to client requests.
+# A Pod is considered "ready" when it has completed initialization and should be one of the backends for a K8s Service resource.
+# TODO: Enable/disable probes as required, and set appropriate values.
+livenessProbe:
+  enable: true
+  initialDelaySeconds: 300
+  periodSeconds: 30
+  failureThreshold: 6
+  http:
+    path: /
+readinessProbe:
+  enable: true
+  initialDelaySeconds: 300
+  periodSeconds: 30
+  failureThreshold: 6
+  http:
+    path: /
+
+# service declares the type of Service resource to be created, as well as the target port of the Pod to send requests.
+service:
+  type: ClusterIP
+  port: 80
+
+# ingress declares the Ingress resource to be created and allow access to the service from the external internet.
+# Set ingress.enabled to true to create this Ingress resource. Double-check the host values for your application.
+# TODO: Review ingress values.
+ingress:
+  enabled: false
+  className: "haproxy"
+  annotations: {}
+    # cert-manager.io/cluster-issuer: rutgers-acme
+  # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: example-application.k8s.rcsb.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: example-application-tls
+  #    hosts:
+  #      - example-application.k8s.rcsb.org
+
+# Define resource limits for your application. Especially important if you enable autoscaling for this Helm chart.
+# Deploy without limits first to test the application performance, then tune afterwards to ensure that autoscaling
+# will work as expected.
+# TODO: Review resource limit values.
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+#   memory: 128Mi
+
+# usePersistentVolume if your application requires a persistent volume resource for data storage.
+# TODO: Review persistent volume values as required.
+usePersistentVolume: false
+# persistentVolumeMountPath defines the local path within the container where the persistent volume will be mounted.
+persistentVolumeMountPath: ""
+persistentVolumeReadOnly: true
+rookCeph:
+  metadataPoolSize: 3
+  dataPoolSize: 3
+  preserveFilesystemOnDelete: false
+  # reclaimPolicy are either Delete or Retain. See https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming
+  reclaimPolicy: Retain
+  allowVolumeExpansion: true
+  pvcRequestStorageSize: 50G
+  pvcAccessModes:
+    - ReadWriteMany
+
+# useSecretsVolume if your application will mount a secret from the Vault service as a file on the filesystem.
+useSecretsVolume: false
+secretVolumes: {}
+#  - name: Name of the volume reference in the Deployment resource
+#    mountPath: Full path in the container to mount the secret file
+#    filename: The filename of the secret file to mount
+#    secretName: Name of the Secret resource in K8s
+
+# appConfigs defines ConfigMap resources which are mounted into the container environment as a file.
+useAppConfigs: false
+appConfigs: {}
+#  example.log4j.xml:
+#    mountPath: Full path in the container to mount this config file
+#    filename: The filename of the config file to mount
+#    value: |-
+#      <example>
+#        Can be any other file types besides xml as well!
+#      </example>

--- a/templates/helm/values/staging.yaml
+++ b/templates/helm/values/staging.yaml
@@ -32,12 +32,12 @@ externalSecret:
   enabled: false
   secretStoreRefName: "rcsb-vault"
   targets:
-    secretName: # Name of the secret resource to create in K8s
-    data: {}
-    # - secretKey: key_name_to_create_in_Secret_k8s_resource
-    #   remoteRef:
-    #     key: vault_engine_name/secret_name
-    #     property: name_of_key_of_secret_in_vault
+    - secretName: # Name of the secret resource to create in K8s
+      data: {}
+      #  - secretKey: key_name_to_create_in_Secret_k8s_resource
+      #    remoteRef:
+      #      key: vault_engine_name/secret_name
+      #      property: name_of_key_of_secret_in_vault
 
 # imagePullSecrets is the Secret resource which contains the credentials to connect to Docker
 # to pull images from private Harbor projects. If the image for your Helm chart is not from a

--- a/templates/helm/values/staging.yaml
+++ b/templates/helm/values/staging.yaml
@@ -1,0 +1,156 @@
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+# TODO: Remove any extra comment blocks and unused variable values.
+
+# Number of running Pods managed by this Helm chart's Deployment resource.
+# If using autoscaling, comment or remove this value.
+replicaCount: 1
+
+# Configure a HorizontalPodAutoscaler resource for this Helm chart's Deployment resource.
+# Set autoscaling.enabled to true to enable this functionality. If using this resource,
+# either choose to scale by targetCPUUtilizationPercentage or targetMemoryUtilizationPercentage
+# based on how you want the Deployment to scale, and comment or remove the other value option.
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# The Docker image reference which this Helm chart will run.
+# TODO: Ensure the repository/image name is correct.
+image:
+  repository: "harbor.devops.k8s.rcsb.org/rcsb/example_application"
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+# externalSecret defines values for the ExternalSecret resource if your application needs to pull values
+# from an external Vault service.
+# TODO: Review externalSecret values as required.
+externalSecret:
+  enabled: false
+  secretStoreRefName: "rcsb-vault"
+  targets:
+    secretName: # Name of the secret resource to create in K8s
+    data: {}
+    # - secretKey: key_name_to_create_in_Secret_k8s_resource
+    #   remoteRef:
+    #     key: vault_engine_name/secret_name
+    #     property: name_of_key_of_secret_in_vault
+
+# imagePullSecrets is the Secret resource which contains the credentials to connect to Docker
+# to pull images from private Harbor projects. If the image for your Helm chart is not from a
+# private Harbor project, you can exclude this value. Otherwise, leave this value as is.
+imagePullSecrets: "harbor-docker-registry-conf"
+
+deploymentStrategy:
+  #https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+  #Type is either RollingUpdate or Recreate
+  type: "RollingUpdate"
+  #For rolling update, what percentage of total pods can be created above desired amount
+  maxSurge: 25%
+  #For rolling update, what percentage of total pods can be brought down to update
+  maxUnavailable: 25%
+
+# securityContext sets the container security values of the Pod. These default values are the recommended
+# values for all applications. Adjust as needed for your application purposes, but be aware of the security
+# implications from these changes.
+securityContext:
+  capabilities:
+    drop:
+      - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 1000
+
+# Define container liveness and readiness checks
+# A Pod is considered "live" when it is able to respond to client requests.
+# A Pod is considered "ready" when it has completed initialization and should be one of the backends for a K8s Service resource.
+# TODO: Enable/disable probes as required, and set appropriate values.
+livenessProbe:
+  enable: true
+  initialDelaySeconds: 300
+  periodSeconds: 30
+  failureThreshold: 6
+  http:
+    path: /
+readinessProbe:
+  enable: true
+  initialDelaySeconds: 300
+  periodSeconds: 30
+  failureThreshold: 6
+  http:
+    path: /
+
+# service declares the type of Service resource to be created, as well as the target port of the Pod to send requests.
+service:
+  type: ClusterIP
+  port: 80
+
+# ingress declares the Ingress resource to be created and allow access to the service from the external internet.
+# Set ingress.enabled to true to create this Ingress resource. Double-check the host values for your application.
+# TODO: Review ingress values.
+ingress:
+  enabled: false
+  className: "haproxy"
+  annotations: {}
+    # cert-manager.io/cluster-issuer: rutgers-acme
+  # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: example-application.k8s.rcsb.org
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: example-application-tls
+  #    hosts:
+  #      - example-application.k8s.rcsb.org
+
+# Define resource limits for your application. Especially important if you enable autoscaling for this Helm chart.
+# Deploy without limits first to test the application performance, then tune afterwards to ensure that autoscaling
+# will work as expected.
+# TODO: Review resource limit values.
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+#   memory: 128Mi
+
+# usePersistentVolume if your application requires a persistent volume resource for data storage.
+# TODO: Review persistent volume values as required.
+usePersistentVolume: false
+# persistentVolumeMountPath defines the local path within the container where the persistent volume will be mounted.
+persistentVolumeMountPath: ""
+persistentVolumeReadOnly: true
+rookCeph:
+  metadataPoolSize: 3
+  dataPoolSize: 3
+  preserveFilesystemOnDelete: false
+  # reclaimPolicy are either Delete or Retain. See https://kubernetes.io/docs/concepts/storage/persistent-volumes/#reclaiming
+  reclaimPolicy: Retain
+  allowVolumeExpansion: true
+  pvcRequestStorageSize: 50G
+  pvcAccessModes:
+    - ReadWriteMany
+
+# useSecretsVolume if your application will mount a secret from the Vault service as a file on the filesystem.
+useSecretsVolume: false
+secretVolumes: {}
+#  - name: Name of the volume reference in the Deployment resource
+#    mountPath: Full path in the container to mount the secret file
+#    filename: The filename of the secret file to mount
+#    secretName: Name of the Secret resource in K8s
+
+# appConfigs defines ConfigMap resources which are mounted into the container environment as a file.
+useAppConfigs: false
+appConfigs: {}
+#  example.log4j.xml:
+#    mountPath: Full path in the container to mount this config file
+#    filename: The filename of the config file to mount
+#    value: |-
+#      <example>
+#        Can be any other file types besides xml as well!
+#      </example>

--- a/templates/skaffold.yaml
+++ b/templates/skaffold.yaml
@@ -1,0 +1,34 @@
+apiVersion: skaffold/v3
+kind: Config
+profiles:
+  - name: dev
+    deploy:
+      helm:
+        flags:
+          upgrade:
+            - --install
+        releases:
+          - name: skaffold-<example_application>
+            chartPath: k8s/helm
+  - name: staging
+    deploy:
+      helm:
+        flags:
+          upgrade:
+            - --install
+        releases:
+          - name: skaffold-<example_application>
+            chartPath: k8s/helm
+            valuesFiles:
+              - k8s/helm/values/staging.yaml
+  - name: production
+    deploy:
+      helm:
+        flags:
+          upgrade:
+            - --install
+        releases:
+          - name: skaffold-<example_application>
+            chartPath: k8s/helm
+            valuesFiles:
+              - k8s/helm/values/production.yaml


### PR DESCRIPTION
Create a directory that contains an example Helm Chart template. Mostly for DevOps team to have a reference location for common resources and values we use in our Helm Charts. Devs should be able to also use this as a starting point if they want to create their own Helm Charts for an application.