### PR TITLE
Java workflow: add 'production' tag using the existing push-to-master + release workflow

### DIFF
--- a/.github/workflows/build-and-push-docker.yaml
+++ b/.github/workflows/build-and-push-docker.yaml
@@ -21,4 +21,5 @@ jobs:
       - uses: actions/checkout@v4
       - name: Build and Push via jib
         run: |
+          echo "Will build with maven jib and push to Harbor with tag [ ${{ inputs.tag }} ] and target namespace [ ${{ inputs.namespace }} ]"
           mvn package jib:build -Djib.to.tags=${{ inputs.tag }} -Djib.target.namespace=${{ inputs.namespace }} --no-transfer-progress -Dmaven.test.skip=true -Djib.httpTimeout=0

--- a/.github/workflows/push-to-master.yaml
+++ b/.github/workflows/push-to-master.yaml
@@ -52,6 +52,7 @@ jobs:
       major: "${{needs.extract.outputs.major}}"
       minor: "${{needs.extract.outputs.minor}}"
       patch: "${{needs.extract.outputs.patch}}"
+      extra-tags: "production"
       skip-tests : true
       distribution: "${{ inputs.distribution }}"
       type: "${{ inputs.type }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,10 @@ on:
         description: 'Patch version'
         type: string
         required: true
+      extra-tags:
+        description: 'Extra tags to be used when pushing the image to image repo. Comma separated list. A tag with major.minor.patch will always be created.'
+        type: string
+        required: false
       skip-tests:
         description: 'Skip tests'
         type: boolean
@@ -28,6 +32,8 @@ on:
         description: 'buildlocker distribution type [war|jar*]'
         type: string
         required: false
+env:
+  VERSION_TAG: "${{ inputs.major }}.${{ inputs.minor }}.${{ inputs.patch }}"
 
 jobs:
   run-tests:
@@ -42,7 +48,11 @@ jobs:
   call-build-and-push-docker:
     uses: rcsb/devops-cicd-github-actions/.github/workflows/build-and-push-docker.yaml@master
     with:
-      tag: "${{ inputs.major }}.${{ inputs.minor }}.${{ inputs.patch }}"
+      # build the tags comma separated string. No idea how people did this before ChatGPT
+      # e.g.
+      #   if VERSION_TAG=1.2.3 and extra-tags='' then this will give '1.2.3'
+      #   if VERSION_TAG=1.2.3 and extra-tags='myextratag' then this will give '1.2.3,myextratag'
+      tag: ${{ env.VERSION_TAG }}${{ inputs.extra-tags && format(', {0}', inputs.extra-tags) || '' }}
   call-deploy-to-build-locker:
     needs:
       - call-build-and-push-docker

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,8 +50,8 @@ jobs:
     with:
       # build the tags comma separated string. No idea how people did this before ChatGPT
       # e.g.
-      #   if VERSION_TAG=1.2.3 and extra-tags='' then this will give '1.2.3'
-      #   if VERSION_TAG=1.2.3 and extra-tags='myextratag' then this will give '1.2.3,myextratag'
+      #   if VERSION_TAG='1.2.3' and extra-tags='' then this will give '1.2.3'
+      #   if VERSION_TAG='1.2.3' and extra-tags='myextratag' then this will give '1.2.3,myextratag'
       tag: ${{ env.VERSION_TAG }}${{ inputs.extra-tags && format(',{0}', inputs.extra-tags) || '' }}
   call-deploy-to-build-locker:
     needs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,7 +52,7 @@ jobs:
       # e.g.
       #   if VERSION_TAG=1.2.3 and extra-tags='' then this will give '1.2.3'
       #   if VERSION_TAG=1.2.3 and extra-tags='myextratag' then this will give '1.2.3,myextratag'
-      tag: ${{ env.VERSION_TAG }}${{ inputs.extra-tags && format(', {0}', inputs.extra-tags) || '' }}
+      tag: ${{ env.VERSION_TAG }}${{ inputs.extra-tags && format(',{0}', inputs.extra-tags) || '' }}
   call-deploy-to-build-locker:
     needs:
       - call-build-and-push-docker


### PR DESCRIPTION
This is an attempt to unify `push-to-master` and `workflow-java`. In my understanding the one extra thing that `workflow-java` was doing is adding the `production` tag. With this PR `push-to-master` also adds the `production` tag. If someone knows of other reasons why we were trying to move towards `workflow-java` please let me know.

With this in place what we would need in a java workflow is:

1. `push-to-branch`
2. `push-to-master`
3. `release`

(no need of workflow-java`)

I am proposing this because `push-to-master` (which also calls `release`) was more complete than `workflow-java`, so this feels an easier way to unify than adding all the other functionality (rolling versions etc) to `workflow-java`.

Note I need to test this once merged. It is not easy to test things out in ghw